### PR TITLE
Fix URL typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Coffee2D currently provides:
 * Tweening
 * Isometric maps
 
-To get started, check out the code in the [example](https://github.com/LanJian/coffee2d/tree/master/example) folder.
+To get started, check out the code in the [examples](https://github.com/LanJian/coffee2d/tree/master/examples) folder.
 
 To build, run `make clean && make build`. This creates the file `build/engine-all.js`, which can be dropped into any project that wants to use Coffee2D
 


### PR DESCRIPTION
The link to the examples directory in the README.md returned a 404. Fixed the link.
